### PR TITLE
fix subscription bug where turn updates gradually slow down due to connection overload

### DIFF
--- a/src/components/Board.tsx
+++ b/src/components/Board.tsx
@@ -21,14 +21,12 @@ import * as Types from '../types';
 import { TopOfDeck } from './CardRowAndStack';
 import { GameStateProvider } from './useGameState';
 
-export const Board = ({ subscribeToGame, playerId, data, loading, error }: {
-  subscribeToGame: () => void;
+export const Board = ({ playerId, data, loading, error }: {
   playerId: string;
   data: Types.GameBoard | undefined;
   loading: boolean;
   error: ApolloError | undefined;
 }) => {
-  useEffect(() => subscribeToGame());
 
   const turn = data?.game?.currentTurn?.id;
   const lastTurn = data?.game?.turns.slice(-1)[0];

--- a/src/containers/BoardContainer.tsx
+++ b/src/containers/BoardContainer.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { useQuery } from '@apollo/client';
 import { GAME_BOARD_QUERY } from '../gql/queries';
 import { GAME_BOARD_SUBSCRIPTION } from '../gql/subscriptions';
@@ -16,23 +16,22 @@ export const BoardContainer: React.FC<{ gameId: string; playerId: string }> = ({
     }
   );
 
+  useEffect(() => subscribeToMore({
+    document: GAME_BOARD_SUBSCRIPTION,
+    variables: { gameId, playerId },
+    updateQuery: (prev, { subscriptionData }) => {
+      console.log('GAME_BOARD_SUBSCRIPTION update!');
+      if (!subscriptionData.data) return prev;
+      return Object.assign({}, prev, subscriptionData.data);
+    },
+  }), [gameId, playerId, subscribeToMore])
+
   return (
     <Board
       data={data}
       loading={loading}
       error={error}
       playerId={playerId}
-      subscribeToGame={() => {
-        subscribeToMore({
-          document: GAME_BOARD_SUBSCRIPTION,
-          variables: { gameId, playerId },
-          updateQuery: (prev, { subscriptionData }) => {
-            console.log('GAME_BOARD_SUBSCRIPTION update!');
-            if (!subscriptionData.data) return prev;
-            return Object.assign({}, prev, subscriptionData.data);
-          },
-        });
-      }}
     />
   );
 };


### PR DESCRIPTION
since there was a useEffect calling subscribeToGame with no dependencies provided, 
<details>
<summary>
websocket connections were being created on each `render` of the Board
</summary>

![image](https://user-images.githubusercontent.com/743976/94636875-33177700-02a4-11eb-860e-5a9b0e13dfa9.png)

</details>

It'd gradually get so that a single player's page would have hundreds of open websocket connections and overwhelm the server (we could maybe add some server-side protections to limit connections-per IP)

This PR fixes 2 things

- new connections are only created as need (when `gameId, playerId, subscribeToMore` changes, which should be never)
- the old connection is cleaned up (`subscribeToMore` returns its own cleanup function, which we return in the callback of useEffect)