### PR TITLE
Fix affordability indicator not taking purchased cards into account

### DIFF
--- a/src/components/Board.tsx
+++ b/src/components/Board.tsx
@@ -76,7 +76,10 @@ export const Board = ({ playerId, data, loading, error }: {
     return (
       <GameStateProvider gameState={{
         ...game,
-        me,
+        me: {
+          ...me,
+          purchasingPower: getPlayerPurchasingPower(me),
+        },
       }}>
         <Helmet>
           <title>
@@ -199,3 +202,32 @@ export const Board = ({ playerId, data, loading, error }: {
     );
   } else return (<></>)
 }
+
+const getPlayerPurchasingPower = ({
+  bank,
+  purchasedCards,
+}: Types.GameBoard_game_players) => {
+
+  const purchasingPowerFromGems: Record<Types.GemColor, number> = bank.reduce(
+    (partialPurchasingPower, gemCategory) => ({
+      ...partialPurchasingPower,
+      [gemCategory.gemColor]: gemCategory.quantity,
+    }),
+    {
+      BLACK: 0,
+      BLUE: 0,
+      GREEN: 0,
+      RED: 0,
+      WHITE: 0,
+      YELLOW: 0,
+    }
+  );
+
+  return purchasedCards.reduce((partialPurchasingPower, card) => {
+    if (!card.gemColor) return partialPurchasingPower;
+    return {
+      ...partialPurchasingPower,
+      [card.gemColor]: partialPurchasingPower[card.gemColor] + 1,
+    };
+  }, purchasingPowerFromGems);
+};

--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -70,8 +70,7 @@ export const Card: React.FC<{
                   ? Math.max(
                       0,
                       quantity -
-                        (me.bank.find((myBank) => myBank.gemColor === gemColor)
-                          ?.quantity ?? 0)
+                        (me.purchasingPower[gemColor])
                     )
                   : quantity
               }

--- a/src/components/useGameState.tsx
+++ b/src/components/useGameState.tsx
@@ -2,8 +2,10 @@ import React from 'react';
 import * as Types from '../types';
 
 type GameState = Types.GameBoard_game & {
-  me: Types.GameBoard_game_players
-}
+  me: Types.GameBoard_game_players & {
+    purchasingPower: Record<Types.GemColor, number>;
+  };
+};
 
 const GameStateContext = React.createContext<GameState | null | undefined>(
   undefined


### PR DESCRIPTION
follow up to https://github.com/daniman/splendor-client/pull/32 , which had a bug where it didn't account for purchasing-power added by purchased development cards