### PR TITLE
show gem colors in turn log

### DIFF
--- a/src/components/MoveLog.tsx
+++ b/src/components/MoveLog.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import moment from 'moment';
 import * as Types from '../types';
 import { Small } from './Lobby';
+import { colors } from '../config/colors';
 
 export const MoveLog: React.FC<{
   turns: Types.GameBoard_game_turns[];
@@ -23,7 +24,28 @@ export const MoveLog: React.FC<{
             <code>{t.playerId}</code>{' '}
             {t.__typename === 'TakeGems' ? (
               <span>
-                <Small>took</Small> <code>{t.gems.join(', ')}</code>{' '}
+                <Small>took</Small>{" "}
+                <code>
+                  {t.gems.map((gemColor) => (
+                    <>
+                    <div
+                      key={gemColor}
+                      style={{
+                        display: "inline-block",
+                        marginLeft: 4,
+                        marginRight: 2,
+                        height: 10,
+                        width: 10,
+                        borderRadius: 5,
+                        backgroundColor: !!gemColor
+                          ? colors[gemColor]
+                          : "#FFFFFF",
+                      }}
+                    />
+                    <span style={{ marginLeft: 2, color: colors[gemColor] }}>{gemColor}</span>
+                    </>
+                  ))}
+                </code>{" "}
                 <Small>gems</Small>
               </span>
             ) : t.__typename === 'PurchaseCard' ? (


### PR DESCRIPTION
makes turn logs a bit easier to skim
before | after
-|-
![image](https://user-images.githubusercontent.com/743976/94759738-bb624e80-036e-11eb-8ba0-3ea15a7ef3c3.png)| ![image](https://user-images.githubusercontent.com/743976/94759697-9ec61680-036e-11eb-8d3b-774a6d813aa1.png)
