### PR TITLE
move turn log up into same row as GameCardStacks

### DIFF
--- a/src/components/Board.tsx
+++ b/src/components/Board.tsx
@@ -132,6 +132,8 @@ export const Board = ({ playerId, data, loading, error }: {
               turnCardState={turnCardState}
               setTurnCardState={setTurnCardState}
             />
+
+            <MoveLog turns={game.turns} />
           </div>
           <div
             className="col-lg-6 col-md-6 col-sm-12 col-xs-12"
@@ -191,11 +193,6 @@ export const Board = ({ playerId, data, loading, error }: {
               turnCardState={turnCardState}
               setTurnCardState={setTurnCardState}
             />
-          </div>
-        </div>
-        <div className="row">
-          <div className="col-lg-6">
-            <MoveLog turns={game.turns} />
           </div>
         </div>
       </GameStateProvider>

--- a/src/components/MoveLog.tsx
+++ b/src/components/MoveLog.tsx
@@ -9,7 +9,7 @@ export const MoveLog: React.FC<{
   turns: Types.GameBoard_game_turns[];
 }> = ({ turns }) => (
   <div>
-    <h3 style={{ marginTop: 20 }}>Turn Log:</h3>
+    <h3 style={{ marginTop: 0 }}>Turn Log:</h3>
     <div className="moveLog">
       {turns
         .slice()


### PR DESCRIPTION
As the player purchases cards, the first row's right column grows higher, which pushes the turn log lower

This PR moves turn log into the first row, nestled under GameCardStacks

before|after
-|-
![image](https://user-images.githubusercontent.com/743976/97063723-56fe6d80-156f-11eb-93fe-f10387bb2d1e.png)|![image](https://user-images.githubusercontent.com/743976/97063728-61206c00-156f-11eb-8d91-41447c0d8517.png)


helps make https://github.com/daniman/splendor-client/issues/27 a bit better?